### PR TITLE
Move predis to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
     }
   ],
   "require": {
-    "predis/predis": "1.0.*",
     "php": ">=5.3.0"
   },
   "require-dev": {
+    "predis/predis": "1.0.*",
     "phpunit/phpunit": "4.*",
     "satooshi/php-coveralls": "0.7.*@dev"
   },


### PR DESCRIPTION
We don't require predis because we might not be using predis.
