### PR TITLE
Tidy up Travis definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
 
 script:
   - mkdir -p build/logs
-  - php vendor/bin/phpunit -c phpunit.xml
+  - vendor/bin/phpunit
 
 after_script:
-  - php vendor/bin/coveralls -v
+  - vendor/bin/coveralls -v


### PR DESCRIPTION
Binaries don't need to be explicitly run through the PHP interpreter because they're binaries.
PHPUnit already looks in the working directory for `phpunit.xml`.
