### PR TITLE
Upgrade code to work in PHP8 or greater and/or Laravel 9 or greater

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ composer require voku/simple-cache
 ### Quick Start
 
 ```php
-use voku\cache\Cache;
+use Voku\Cache\Cache;
 
 require_once 'composer/autoload.php';
 
@@ -57,7 +57,7 @@ $bar = $cache->getItem('foo');
 ### Usage 
 
 ```php
-use voku\cache\Cache;
+use Voku\Cache\Cache;
 
 $cache = new Cache();
   
@@ -74,7 +74,7 @@ If you have an heavy task e.g. a really-big-loop, then you can also use static-c
 But keep in mind, that this will be stored into PHP (it needs more memory).
 
 ```php
-use voku\cache\Cache;
+use Voku\Cache\Cache;
 
 $cache = new Cache();
   
@@ -108,21 +108,21 @@ you can implement your own cache auto-detect logic.
 
 ```php
 
-$cacheManager = new \voku\cache\CacheAdapterAutoManager();
+$cacheManager = new \Voku\Cache\CacheAdapterAutoManager();
 
 // 1. check for "APCu" support first
 $cacheManager->addAdapter(
-    \voku\cache\AdapterApcu::class
+    \Voku\Cache\AdapterApcu::class
 );
 
 // 2. check for "APC" support
 $cacheManager->addAdapter(
-    \voku\cache\AdapterApcu::class
+    \Voku\Cache\AdapterApcu::class
 );
 
 // 3. try "OpCache"-Cache
 $cacheManager->addAdapter(
-    \voku\cache\AdapterOpCache::class,
+    \Voku\Cache\AdapterOpCache::class,
     static function () {
         $cacheDir = \realpath(\sys_get_temp_dir()) . '/simple_php_cache_opcache';
 
@@ -132,7 +132,7 @@ $cacheManager->addAdapter(
 
 // 4. try "File"-Cache
 $cacheManager->addAdapter(
-    \voku\cache\AdapterFileSimple::class,
+    \Voku\Cache\AdapterFileSimple::class,
     static function () {
         $cacheDir = \realpath(\sys_get_temp_dir()) . '/simple_php_cache_file';
 
@@ -143,10 +143,10 @@ $cacheManager->addAdapter(
 
 // 5. use Memory Cache as final fallback
 $cacheManager->addAdapter(
-    \voku\cache\AdapterArray::class
+    \Voku\Cache\AdapterArray::class
 );
 
-$cache = new \voku\cache\CachePsr16(
+$cache = new \Voku\Cache\CachePsr16(
     null, // use auto-detection
     null, // use auto-detection
     false, // do not check for usage

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "psr/simple-cache-implementation": "1.0"
   },
   "require": {
-    "php": ">=7.0.0",
+    "php": "^8.0 || ^8.1 || ^8.2",
     "psr/simple-cache": "~1.0 || ~2.0"
   },
   "require-dev": {
@@ -33,7 +33,7 @@
   },
   "autoload": {
     "psr-4": {
-      "voku\\cache\\": "src/voku/cache/"
+      "Voku\\Cache\\": "src/voku/cache/"
     }
   }
 }

--- a/src/voku/cache/AdapterApc.php
+++ b/src/voku/cache/AdapterApc.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
 /**
  * AdapterApc: a APC-Cache adapter

--- a/src/voku/cache/AdapterApcu.php
+++ b/src/voku/cache/AdapterApcu.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
 /**
  * AdapterApcu: a APCu-Cache adapter

--- a/src/voku/cache/AdapterArray.php
+++ b/src/voku/cache/AdapterArray.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
 /**
  * AdapterArray: simple array-cache adapter

--- a/src/voku/cache/AdapterFile.php
+++ b/src/voku/cache/AdapterFile.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
 /**
  * AdapterFile: File-adapter

--- a/src/voku/cache/AdapterFileAbstract.php
+++ b/src/voku/cache/AdapterFileAbstract.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
 /**
  * AdapterFileSimple: File-adapter (simple)

--- a/src/voku/cache/AdapterFileSimple.php
+++ b/src/voku/cache/AdapterFileSimple.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
 /**
  * AdapterFileSimple: File-adapter (simple)

--- a/src/voku/cache/AdapterMemcache.php
+++ b/src/voku/cache/AdapterMemcache.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
 use Memcache;
-use voku\cache\Exception\InvalidArgumentException;
+use Voku\Cache\Exception\InvalidArgumentException;
 
 /**
  * AdapterMemcache: Memcache-adapter

--- a/src/voku/cache/AdapterMemcached.php
+++ b/src/voku/cache/AdapterMemcached.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
 use Memcached;
-use voku\cache\Exception\InvalidArgumentException;
+use Voku\Cache\Exception\InvalidArgumentException;
 
 /**
  * AdapterMemcached: Memcached-adapter

--- a/src/voku/cache/AdapterOpCache.php
+++ b/src/voku/cache/AdapterOpCache.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
 /**
  * AdapterOpCache: PHP-OPcache

--- a/src/voku/cache/AdapterPredis.php
+++ b/src/voku/cache/AdapterPredis.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
 use Predis\Client;
 

--- a/src/voku/cache/AdapterXcache.php
+++ b/src/voku/cache/AdapterXcache.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
 /**
  * AdapterXcache: Xcache-adapter

--- a/src/voku/cache/Cache.php
+++ b/src/voku/cache/Cache.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
-use voku\cache\Exception\InvalidArgumentException;
+use Voku\Cache\Exception\InvalidArgumentException;
 
 /**
  * Cache: global-cache class

--- a/src/voku/cache/CacheAdapterAutoManager.php
+++ b/src/voku/cache/CacheAdapterAutoManager.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
-use voku\cache\Exception\InvalidArgumentException;
+use Voku\Cache\Exception\InvalidArgumentException;
 
 class CacheAdapterAutoManager
 {

--- a/src/voku/cache/CacheChain.php
+++ b/src/voku/cache/CacheChain.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
 class CacheChain implements iCache
 {

--- a/src/voku/cache/CachePsr16.php
+++ b/src/voku/cache/CachePsr16.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
 use Psr\SimpleCache\CacheInterface;
-use voku\cache\Exception\InvalidArgumentException;
+use Voku\Cache\Exception\InvalidArgumentException;
 
 class CachePsr16 extends Cache implements CacheInterface
 {

--- a/src/voku/cache/Exception/ChmodException.php
+++ b/src/voku/cache/Exception/ChmodException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache\Exception;
+namespace Voku\Cache\Exception;
 
 final class ChmodException extends \RuntimeException implements FileErrorExceptionInterface
 {

--- a/src/voku/cache/Exception/FileErrorExceptionInterface.php
+++ b/src/voku/cache/Exception/FileErrorExceptionInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache\Exception;
+namespace Voku\Cache\Exception;
 
 interface FileErrorExceptionInterface
 {

--- a/src/voku/cache/Exception/InvalidArgumentException.php
+++ b/src/voku/cache/Exception/InvalidArgumentException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache\Exception;
+namespace Voku\Cache\Exception;
 
 class InvalidArgumentException extends \Exception implements \Psr\SimpleCache\InvalidArgumentException
 {

--- a/src/voku/cache/Exception/RenameException.php
+++ b/src/voku/cache/Exception/RenameException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache\Exception;
+namespace Voku\Cache\Exception;
 
 final class RenameException extends \RuntimeException implements FileErrorExceptionInterface
 {

--- a/src/voku/cache/Exception/RuntimeException.php
+++ b/src/voku/cache/Exception/RuntimeException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache\Exception;
+namespace Voku\Cache\Exception;
 
 final class RuntimeException extends \RuntimeException implements FileErrorExceptionInterface
 {

--- a/src/voku/cache/Exception/WriteContentException.php
+++ b/src/voku/cache/Exception/WriteContentException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache\Exception;
+namespace Voku\Cache\Exception;
 
 final class WriteContentException extends \RuntimeException implements FileErrorExceptionInterface
 {

--- a/src/voku/cache/SerializerDefault.php
+++ b/src/voku/cache/SerializerDefault.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
 /**
  * SerializerDefault: simple serialize / unserialize

--- a/src/voku/cache/SerializerIgbinary.php
+++ b/src/voku/cache/SerializerIgbinary.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
 /**
  * SerializerIgbinary: serialize / unserialize

--- a/src/voku/cache/SerializerMsgpack.php
+++ b/src/voku/cache/SerializerMsgpack.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
 /**
  * SerializerMsgpack: serialize / unserialize

--- a/src/voku/cache/SerializerNo.php
+++ b/src/voku/cache/SerializerNo.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
 /**
  * SerializerNo: no serialize / unserialize !!!

--- a/src/voku/cache/iAdapter.php
+++ b/src/voku/cache/iAdapter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
 /**
  * iAdapter: cache-adapter interface

--- a/src/voku/cache/iCache.php
+++ b/src/voku/cache/iCache.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
 use DateTimeInterface;
 

--- a/src/voku/cache/iSerializer.php
+++ b/src/voku/cache/iSerializer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\cache;
+namespace Voku\Cache;
 
 /**
  * iSerializer: cache-serializer interface

--- a/tests/ApcCacheTest.php
+++ b/tests/ApcCacheTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use voku\cache\AdapterApc;
-use voku\cache\Cache;
-use voku\cache\iAdapter;
-use voku\cache\iSerializer;
-use voku\cache\SerializerDefault;
+use Voku\Cache\AdapterApc;
+use Voku\Cache\Cache;
+use Voku\Cache\iAdapter;
+use Voku\Cache\iSerializer;
+use Voku\Cache\SerializerDefault;
 
 /**
  * ApcCacheTest

--- a/tests/ApcuCacheTest.php
+++ b/tests/ApcuCacheTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use voku\cache\AdapterApcu;
-use voku\cache\Cache;
-use voku\cache\iAdapter;
-use voku\cache\iSerializer;
-use voku\cache\SerializerMsgpack;
+use Voku\Cache\AdapterApcu;
+use Voku\Cache\Cache;
+use Voku\Cache\iAdapter;
+use Voku\Cache\iSerializer;
+use Voku\Cache\SerializerMsgpack;
 
 /**
  * ApcuCacheTest

--- a/tests/ArrayCacheTest.php
+++ b/tests/ArrayCacheTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use voku\cache\AdapterArray;
-use voku\cache\Cache;
-use voku\cache\iAdapter;
-use voku\cache\iSerializer;
-use voku\cache\SerializerDefault;
+use Voku\Cache\AdapterArray;
+use Voku\Cache\Cache;
+use Voku\Cache\iAdapter;
+use Voku\Cache\iSerializer;
+use Voku\Cache\SerializerDefault;
 
 /**
  * ArrayCacheTest

--- a/tests/CacheAutoInitOverwriteTest.php
+++ b/tests/CacheAutoInitOverwriteTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use voku\cache\Cache;
-use voku\cache\iAdapter;
-use voku\cache\iSerializer;
+use Voku\Cache\Cache;
+use Voku\Cache\iAdapter;
+use Voku\Cache\iSerializer;
 
 /**
  * @internal
@@ -92,7 +92,7 @@ final class CacheAutoInitOverwriteTest extends \PHPUnit\Framework\TestCase
 
     public function testSetWrongDate()
     {
-        $this->expectException(\voku\cache\Exception\InvalidArgumentException::class);
+        $this->expectException(\Voku\Cache\Exception\InvalidArgumentException::class);
 
         $key = 'some:test:key';
         $value = \uniqid(\time(), true);
@@ -128,17 +128,17 @@ final class CacheAutoInitOverwriteTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpThanksForNothing()
     {
-        $cacheManager = new \voku\cache\CacheAdapterAutoManager();
+        $cacheManager = new \Voku\Cache\CacheAdapterAutoManager();
         /** @noinspection PhpUnhandledExceptionInspection */
         $cacheManager->addAdapter(
-            \voku\cache\AdapterOpCache::class,
+            \Voku\Cache\AdapterOpCache::class,
             static function () {
                 return \realpath(\sys_get_temp_dir()) . '/simple_php_cache_v2';
             }
         );
         /** @noinspection PhpUnhandledExceptionInspection */
         $cacheManager->addAdapter(
-            \voku\cache\AdapterArray::class
+            \Voku\Cache\AdapterArray::class
         );
 
         $this->cache = new Cache(

--- a/tests/CacheAutoInitReplaceTest.php
+++ b/tests/CacheAutoInitReplaceTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use voku\cache\Cache;
-use voku\cache\iAdapter;
-use voku\cache\iSerializer;
+use Voku\Cache\Cache;
+use Voku\Cache\iAdapter;
+use Voku\Cache\iSerializer;
 
 /**
  * @internal
@@ -92,7 +92,7 @@ final class CacheAutoInitReplaceTest extends \PHPUnit\Framework\TestCase
 
     public function testSetWrongDate()
     {
-        $this->expectException(\voku\cache\Exception\InvalidArgumentException::class);
+        $this->expectException(\Voku\Cache\Exception\InvalidArgumentException::class);
 
         $key = 'some:test:key';
         $value = \uniqid(\time(), true);
@@ -128,10 +128,10 @@ final class CacheAutoInitReplaceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpThanksForNothing()
     {
-        $cacheManager = new \voku\cache\CacheAdapterAutoManager();
+        $cacheManager = new \Voku\Cache\CacheAdapterAutoManager();
         /** @noinspection PhpUnhandledExceptionInspection */
         $cacheManager->addAdapter(
-            \voku\cache\AdapterOpCache::class,
+            \Voku\Cache\AdapterOpCache::class,
             static function () {
                 return \realpath(\sys_get_temp_dir()) . '/simple_php_cache_v3';
             }

--- a/tests/CacheAutoInitTest.php
+++ b/tests/CacheAutoInitTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use voku\cache\Cache;
-use voku\cache\iAdapter;
-use voku\cache\iSerializer;
+use Voku\Cache\Cache;
+use Voku\Cache\iAdapter;
+use Voku\Cache\iSerializer;
 
 /**
  * CacheAutoInitTest
@@ -94,7 +94,7 @@ final class CacheAutoInitTest extends \PHPUnit\Framework\TestCase
 
     public function testSetWrongDate()
     {
-        $this->expectException(\voku\cache\Exception\InvalidArgumentException::class);
+        $this->expectException(\Voku\Cache\Exception\InvalidArgumentException::class);
 
         $key = 'some:test:key';
         $value = \uniqid(\time(), true);

--- a/tests/CacheChainTest.php
+++ b/tests/CacheChainTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use voku\cache\Cache;
+use Voku\Cache\Cache;
 
 /**
  * @internal
@@ -8,7 +8,7 @@ use voku\cache\Cache;
 final class CacheChainTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \voku\cache\CacheChain
+     * @var \Voku\Cache\CacheChain
      */
     private $cache;
 
@@ -190,8 +190,8 @@ final class CacheChainTest extends \PHPUnit\Framework\TestCase
     protected function setUpThanksForNothing()
     {
         $cacheApc = new Cache(
-            new \voku\cache\AdapterApcu(),
-            new \voku\cache\SerializerIgbinary(),
+            new \Voku\Cache\AdapterApcu(),
+            new \Voku\Cache\SerializerIgbinary(),
             false,
             true
         );
@@ -199,15 +199,15 @@ final class CacheChainTest extends \PHPUnit\Framework\TestCase
         $cacheApc->setPrefix('');
 
         $cacheArray = new Cache(
-            new \voku\cache\AdapterArray(),
-            new \voku\cache\SerializerIgbinary(),
+            new \Voku\Cache\AdapterArray(),
+            new \Voku\Cache\SerializerIgbinary(),
             false,
             true
         );
         // reset default prefix
         $cacheArray->setPrefix('');
 
-        $this->cache = new \voku\cache\CacheChain([$cacheApc]);
+        $this->cache = new \Voku\Cache\CacheChain([$cacheApc]);
         $this->cache->addCache($cacheArray);
     }
 }

--- a/tests/CachePsr16Test.php
+++ b/tests/CachePsr16Test.php
@@ -1,8 +1,8 @@
 <?php
 
-use voku\cache\CachePsr16;
-use voku\cache\iAdapter;
-use voku\cache\iSerializer;
+use Voku\Cache\CachePsr16;
+use Voku\Cache\iAdapter;
+use Voku\Cache\iSerializer;
 
 /**
  * CachePsr16Test
@@ -147,11 +147,11 @@ final class CachePsr16Test extends \PHPUnit\Framework\TestCase
     protected function setUpThanksForNothing()
     {
         if (\method_exists($this, 'createMock')) {
-            $this->adapter = $this->createMock('voku\cache\AdapterArray');
-            $this->serializer = $this->createMock('voku\cache\SerializerDefault');
+            $this->adapter = $this->createMock('Voku\Cache\AdapterArray');
+            $this->serializer = $this->createMock('Voku\Cache\SerializerDefault');
         } else {
-            $this->adapter = $this->createMock('voku\cache\AdapterArray');
-            $this->serializer = $this->createMock('voku\cache\SerializerDefault');
+            $this->adapter = $this->createMock('Voku\Cache\AdapterArray');
+            $this->serializer = $this->createMock('Voku\Cache\SerializerDefault');
         }
 
         $this->cache = new CachePsr16($this->adapter, $this->serializer, false, true);

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use voku\cache\Cache;
-use voku\cache\iAdapter;
-use voku\cache\iSerializer;
+use Voku\Cache\Cache;
+use Voku\Cache\iAdapter;
+use Voku\Cache\iSerializer;
 
 /**
  * CacheTest
@@ -133,7 +133,7 @@ final class CacheTest extends \PHPUnit\Framework\TestCase
 
     public function testSetWrongDate()
     {
-        $this->expectException(\voku\cache\Exception\InvalidArgumentException::class);
+        $this->expectException(\Voku\Cache\Exception\InvalidArgumentException::class);
 
         $key = 'some:test:key';
         $value = \uniqid(\time(), true);
@@ -170,8 +170,8 @@ final class CacheTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpThanksForNothing()
     {
-        $this->adapter = $this->createMock('voku\cache\AdapterApc');
-        $this->serializer = $this->createMock('voku\cache\SerializerDefault');
+        $this->adapter = $this->createMock('Voku\Cache\AdapterApc');
+        $this->serializer = $this->createMock('Voku\Cache\SerializerDefault');
 
         $this->cache = new Cache($this->adapter, $this->serializer, false, true);
 

--- a/tests/FileCacheTest.php
+++ b/tests/FileCacheTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use voku\cache\AdapterFile;
-use voku\cache\Cache;
-use voku\cache\iAdapter;
-use voku\cache\iSerializer;
-use voku\cache\SerializerDefault;
+use Voku\Cache\AdapterFile;
+use Voku\Cache\Cache;
+use Voku\Cache\iAdapter;
+use Voku\Cache\iSerializer;
+use Voku\Cache\SerializerDefault;
 
 /**
  * FileCacheTest
@@ -208,12 +208,12 @@ final class FileCacheTest extends \PHPUnit\Framework\TestCase
 
     public function testGetUsedAdapterClassName()
     {
-        static::assertSame('voku\cache\AdapterFile', $this->cache->getUsedAdapterClassName());
+        static::assertSame('Voku\Cache\AdapterFile', $this->cache->getUsedAdapterClassName());
     }
 
     public function testGetUsedSerializerClassName()
     {
-        static::assertSame('voku\cache\SerializerDefault', $this->cache->getUsedSerializerClassName());
+        static::assertSame('Voku\Cache\SerializerDefault', $this->cache->getUsedSerializerClassName());
     }
 
     /**

--- a/tests/FileSimpleCacheTest.php
+++ b/tests/FileSimpleCacheTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use voku\cache\AdapterFileSimple;
-use voku\cache\Cache;
-use voku\cache\iAdapter;
-use voku\cache\iSerializer;
-use voku\cache\SerializerDefault;
+use Voku\Cache\AdapterFileSimple;
+use Voku\Cache\Cache;
+use Voku\Cache\iAdapter;
+use Voku\Cache\iSerializer;
+use Voku\Cache\SerializerDefault;
 
 /**
  * FileSimpleCacheTest
@@ -208,12 +208,12 @@ final class FileSimpleCacheTest extends \PHPUnit\Framework\TestCase
 
     public function testGetUsedAdapterClassName()
     {
-        static::assertSame('voku\cache\AdapterFileSimple', $this->cache->getUsedAdapterClassName());
+        static::assertSame('Voku\Cache\AdapterFileSimple', $this->cache->getUsedAdapterClassName());
     }
 
     public function testGetUsedSerializerClassName()
     {
-        static::assertSame('voku\cache\SerializerDefault', $this->cache->getUsedSerializerClassName());
+        static::assertSame('Voku\Cache\SerializerDefault', $this->cache->getUsedSerializerClassName());
     }
 
     /**

--- a/tests/MemcacheCacheTest.php
+++ b/tests/MemcacheCacheTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use voku\cache\AdapterMemcache;
-use voku\cache\Cache;
-use voku\cache\iAdapter;
-use voku\cache\iSerializer;
-use voku\cache\SerializerNo;
+use Voku\Cache\AdapterMemcache;
+use Voku\Cache\Cache;
+use Voku\Cache\iAdapter;
+use Voku\Cache\iSerializer;
+use Voku\Cache\SerializerNo;
 
 /**
  * MemcacheCacheTest
@@ -75,12 +75,12 @@ final class MemcacheCacheTest extends \PHPUnit\Framework\TestCase
 
     public function testGetUsedAdapterClassName()
     {
-        static::assertSame('voku\cache\AdapterMemcache', $this->cache->getUsedAdapterClassName());
+        static::assertSame('Voku\Cache\AdapterMemcache', $this->cache->getUsedAdapterClassName());
     }
 
     public function testGetUsedSerializerClassName()
     {
-        static::assertSame('voku\cache\SerializerNo', $this->cache->getUsedSerializerClassName());
+        static::assertSame('Voku\Cache\SerializerNo', $this->cache->getUsedSerializerClassName());
     }
 
     public function testSetGetCacheWithEndDateTime()

--- a/tests/MemcachedCacheTest.php
+++ b/tests/MemcachedCacheTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use voku\cache\AdapterMemcached;
-use voku\cache\Cache;
-use voku\cache\iAdapter;
-use voku\cache\iSerializer;
-use voku\cache\SerializerDefault;
+use Voku\Cache\AdapterMemcached;
+use Voku\Cache\Cache;
+use Voku\Cache\iAdapter;
+use Voku\Cache\iSerializer;
+use Voku\Cache\SerializerDefault;
 
 /**
  * MemcachedCacheTest
@@ -125,7 +125,7 @@ final class MemcachedCacheTest extends \PHPUnit\Framework\TestCase
         }
 
         $this->adapter = new AdapterMemcached($memcached);
-        $this->serializer = new \voku\cache\SerializerNo();
+        $this->serializer = new \Voku\Cache\SerializerNo();
 
         if ($this->adapter->installed() === false) {
             static::markTestSkipped('The Memcached extension is not available.');

--- a/tests/OpCacheTest.php
+++ b/tests/OpCacheTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use voku\cache\AdapterOpCache;
-use voku\cache\Cache;
-use voku\cache\iAdapter;
-use voku\cache\iSerializer;
-use voku\cache\SerializerIgbinary;
+use Voku\Cache\AdapterOpCache;
+use Voku\Cache\Cache;
+use Voku\Cache\iAdapter;
+use Voku\Cache\iSerializer;
+use Voku\Cache\SerializerIgbinary;
 
 /**
  * OpCacheTest
@@ -196,12 +196,12 @@ final class OpCacheTest extends \PHPUnit\Framework\TestCase
 
     public function testGetUsedAdapterClassName()
     {
-        static::assertSame('voku\cache\AdapterOpCache', $this->cache->getUsedAdapterClassName());
+        static::assertSame('Voku\Cache\AdapterOpCache', $this->cache->getUsedAdapterClassName());
     }
 
     public function testGetUsedSerializerClassName()
     {
-        static::assertSame('voku\cache\SerializerIgbinary', $this->cache->getUsedSerializerClassName());
+        static::assertSame('Voku\Cache\SerializerIgbinary', $this->cache->getUsedSerializerClassName());
     }
 
     /**

--- a/tests/OpCacheVarExporterTest.php
+++ b/tests/OpCacheVarExporterTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use voku\cache\AdapterOpCache;
-use voku\cache\Cache;
-use voku\cache\iAdapter;
-use voku\cache\iSerializer;
+use Voku\Cache\AdapterOpCache;
+use Voku\Cache\Cache;
+use Voku\Cache\iAdapter;
+use Voku\Cache\iSerializer;
 
 /**
  * @internal
@@ -207,15 +207,15 @@ final class OpCacheVarExporterTest extends \PHPUnit\Framework\TestCase
 
     public function testGetUsedAdapterClassName()
     {
-        static::assertSame('voku\cache\AdapterOpCache', $this->cache->getUsedAdapterClassName());
+        static::assertSame('Voku\Cache\AdapterOpCache', $this->cache->getUsedAdapterClassName());
     }
 
     public function testGetUsedSerializerClassName()
     {
         if (\class_exists('\Symfony\Component\VarExporter\VarExporter')) {
-            static::assertSame('voku\cache\SerializerNo', $this->cache->getUsedSerializerClassName());
+            static::assertSame('Voku\Cache\SerializerNo', $this->cache->getUsedSerializerClassName());
         } else {
-            static::assertSame('voku\cache\SerializerDefault', $this->cache->getUsedSerializerClassName());
+            static::assertSame('Voku\Cache\SerializerDefault', $this->cache->getUsedSerializerClassName());
         }
     }
 
@@ -227,9 +227,9 @@ final class OpCacheVarExporterTest extends \PHPUnit\Framework\TestCase
         $this->adapter = new AdapterOpCache();
 
         if (\class_exists('\Symfony\Component\VarExporter\VarExporter')) {
-            $this->serializer = new \voku\cache\SerializerNo();
+            $this->serializer = new \Voku\Cache\SerializerNo();
         } else {
-            $this->serializer = new \voku\cache\SerializerDefault();
+            $this->serializer = new \Voku\Cache\SerializerDefault();
         }
 
         $this->cache = new Cache($this->adapter, $this->serializer, false, true);

--- a/tests/RedisCacheTest.php
+++ b/tests/RedisCacheTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use voku\cache\AdapterPredis;
-use voku\cache\Cache;
-use voku\cache\iAdapter;
-use voku\cache\iSerializer;
-use voku\cache\SerializerDefault;
+use Voku\Cache\AdapterPredis;
+use Voku\Cache\Cache;
+use Voku\Cache\iAdapter;
+use Voku\Cache\iSerializer;
+use Voku\Cache\SerializerDefault;
 
 /**
  * RedisCacheTest


### PR DESCRIPTION
Fixes: https://github.com/voku/simple-cache/issues/29

This repo doesn't work in PHP 8, 8.1 or 8.2 due to the namespaces not being Capitalized.

* Have updated the namespaces.
* Have updated composer.json and removed php 7 as security updates ended in 28 November 2022.
* Have updated readme with new namespaces

Need to update the connecting repos now.

### Linked to Pull Requests

https://github.com/voku/html-compress-twig/pull/5

https://github.com/voku/HtmlMin/pull/85

https://github.com/voku/simple_html_dom/pull/95

https://github.com/voku/simple-cache/pull/30

https://github.com/voku/portable-ascii/pull/87

### Tested on the following

Tested on PHP 8.2 and Laravel 9.1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/simple-cache/30)
<!-- Reviewable:end -->
