### PR TITLE
AdapterFile: suppress warnings of removed file cache entries

### DIFF
--- a/src/voku/cache/AdapterApc.php
+++ b/src/voku/cache/AdapterApc.php
@@ -116,6 +116,9 @@ class AdapterApc implements iAdapter
 
     /**
      * {@inheritdoc}
+     *
+     * Note: APC automatically handles expiration at the storage level.
+     * The $deleteIfExpired parameter has no effect for this adapter.
      */
     public function get(string $key, bool $deleteIfExpired = true)
     {

--- a/src/voku/cache/AdapterApc.php
+++ b/src/voku/cache/AdapterApc.php
@@ -117,7 +117,7 @@ class AdapterApc implements iAdapter
     /**
      * {@inheritdoc}
      */
-    public function get(string $key)
+    public function get(string $key, bool $deleteIfExpired = true)
     {
         if ($this->exists($key)) {
             return \apc_fetch($key);

--- a/src/voku/cache/AdapterApcu.php
+++ b/src/voku/cache/AdapterApcu.php
@@ -112,7 +112,7 @@ class AdapterApcu implements iAdapter
     /**
      * {@inheritdoc}
      */
-    public function get(string $key)
+    public function get(string $key, bool $deleteIfExpired = true)
     {
         if ($this->exists($key)) {
             return \apcu_fetch($key);

--- a/src/voku/cache/AdapterApcu.php
+++ b/src/voku/cache/AdapterApcu.php
@@ -111,6 +111,9 @@ class AdapterApcu implements iAdapter
 
     /**
      * {@inheritdoc}
+     *
+     * Note: APCu automatically handles expiration at the storage level.
+     * The $deleteIfExpired parameter has no effect for this adapter.
      */
     public function get(string $key, bool $deleteIfExpired = true)
     {

--- a/src/voku/cache/AdapterArray.php
+++ b/src/voku/cache/AdapterArray.php
@@ -46,9 +46,28 @@ class AdapterArray implements iAdapter
     /**
      * {@inheritdoc}
      */
-    public function get(string $key)
+    public function get(string $key, bool $deleteIfExpired = true)
     {
-        return $this->exists($key) ? self::$values[$key] : null;
+        if ($deleteIfExpired) {
+            $this->removeExpired($key);
+        } else {
+            // Check if expired without deleting
+            if (
+                \array_key_exists($key, self::$expired)
+                &&
+                \array_key_exists($key, self::$values)
+            ) {
+                list($time, $ttl) = self::$expired[$key];
+                \assert(\is_int($time));
+                \assert(\is_int($ttl));
+
+                if (\time() > ($time + $ttl)) {
+                    return null;
+                }
+            }
+        }
+
+        return \array_key_exists($key, self::$values) ? self::$values[$key] : null;
     }
 
     /**

--- a/src/voku/cache/AdapterFile.php
+++ b/src/voku/cache/AdapterFile.php
@@ -12,7 +12,7 @@ class AdapterFile extends AdapterFileAbstract
     /**
      * {@inheritdoc}
      */
-    public function get(string $key)
+    public function get(string $key, bool $deleteIfExpired = true)
     {
         $path = $this->getFileName($key);
 
@@ -51,7 +51,9 @@ class AdapterFile extends AdapterFileAbstract
         }
 
         if ($this->ttlHasExpired($data['ttl']) === true) {
-            $this->remove($key);
+            if ($deleteIfExpired) {
+                $this->remove($key);
+            }
 
             return null;
         }

--- a/src/voku/cache/AdapterFileAbstract.php
+++ b/src/voku/cache/AdapterFileAbstract.php
@@ -136,7 +136,7 @@ abstract class AdapterFileAbstract implements iAdapter
     /**
      * {@inheritdoc}
      */
-    abstract public function get(string $key);
+    abstract public function get(string $key, bool $deleteIfExpired = true);
 
     /**
      * {@inheritdoc}

--- a/src/voku/cache/AdapterFileAbstract.php
+++ b/src/voku/cache/AdapterFileAbstract.php
@@ -117,7 +117,7 @@ abstract class AdapterFileAbstract implements iAdapter
     protected function deleteFile($cacheFileWithPath): bool
     {
         if (\is_file($cacheFileWithPath)) {
-            return \unlink($cacheFileWithPath);
+            return @\unlink($cacheFileWithPath);
         }
 
         return false;

--- a/src/voku/cache/AdapterFileSimple.php
+++ b/src/voku/cache/AdapterFileSimple.php
@@ -41,13 +41,13 @@ class AdapterFileSimple extends AdapterFileAbstract
         if (
             \file_exists($path) === false
             ||
-            \filesize($path) === 0
+            @\filesize($path) === 0
         ) {
             return null;
         }
 
         // init
-        $string = \file_get_contents(
+        $string = @\file_get_contents(
             $path,
             false,
             $this->getContext()

--- a/src/voku/cache/AdapterFileSimple.php
+++ b/src/voku/cache/AdapterFileSimple.php
@@ -34,7 +34,7 @@ class AdapterFileSimple extends AdapterFileAbstract
     /**
      * {@inheritdoc}
      */
-    public function get(string $key)
+    public function get(string $key, bool $deleteIfExpired = true)
     {
         $path = $this->getFileName($key);
 
@@ -64,7 +64,9 @@ class AdapterFileSimple extends AdapterFileAbstract
         }
 
         if ($this->ttlHasExpired($data['ttl']) === true) {
-            $this->remove($key);
+            if ($deleteIfExpired) {
+                $this->remove($key);
+            }
 
             return null;
         }

--- a/src/voku/cache/AdapterMemcache.php
+++ b/src/voku/cache/AdapterMemcache.php
@@ -58,6 +58,9 @@ class AdapterMemcache implements iAdapter
 
     /**
      * {@inheritdoc}
+     *
+     * Note: Memcache automatically handles expiration at the storage level.
+     * The $deleteIfExpired parameter has no effect for this adapter.
      */
     public function get(string $key, bool $deleteIfExpired = true)
     {

--- a/src/voku/cache/AdapterMemcache.php
+++ b/src/voku/cache/AdapterMemcache.php
@@ -59,7 +59,7 @@ class AdapterMemcache implements iAdapter
     /**
      * {@inheritdoc}
      */
-    public function get(string $key)
+    public function get(string $key, bool $deleteIfExpired = true)
     {
         return $this->memcache->get($key);
     }

--- a/src/voku/cache/AdapterMemcached.php
+++ b/src/voku/cache/AdapterMemcached.php
@@ -56,7 +56,7 @@ class AdapterMemcached implements iAdapter
     /**
      * {@inheritdoc}
      */
-    public function get(string $key)
+    public function get(string $key, bool $deleteIfExpired = true)
     {
         return $this->memcached->get($key);
     }

--- a/src/voku/cache/AdapterMemcached.php
+++ b/src/voku/cache/AdapterMemcached.php
@@ -55,6 +55,9 @@ class AdapterMemcached implements iAdapter
 
     /**
      * {@inheritdoc}
+     *
+     * Note: Memcached automatically handles expiration at the storage level.
+     * The $deleteIfExpired parameter has no effect for this adapter.
      */
     public function get(string $key, bool $deleteIfExpired = true)
     {

--- a/src/voku/cache/AdapterOpCache.php
+++ b/src/voku/cache/AdapterOpCache.php
@@ -41,7 +41,7 @@ class AdapterOpCache extends AdapterFileSimple
     /**
      * {@inheritdoc}
      */
-    public function get(string $key)
+    public function get(string $key, bool $deleteIfExpired = true)
     {
         $path = $this->getFileName($key);
 
@@ -61,7 +61,9 @@ class AdapterOpCache extends AdapterFileSimple
         }
 
         if ($this->ttlHasExpired($data['ttl']) === true) {
-            $this->remove($key);
+            if ($deleteIfExpired) {
+                $this->remove($key);
+            }
 
             return null;
         }

--- a/src/voku/cache/AdapterPredis.php
+++ b/src/voku/cache/AdapterPredis.php
@@ -53,7 +53,7 @@ class AdapterPredis implements iAdapter
     /**
      * {@inheritdoc}
      */
-    public function get(string $key)
+    public function get(string $key, bool $deleteIfExpired = true)
     {
         return $this->client->get($key);
     }

--- a/src/voku/cache/AdapterPredis.php
+++ b/src/voku/cache/AdapterPredis.php
@@ -52,6 +52,9 @@ class AdapterPredis implements iAdapter
 
     /**
      * {@inheritdoc}
+     *
+     * Note: Redis automatically handles expiration at the storage level.
+     * The $deleteIfExpired parameter has no effect for this adapter.
      */
     public function get(string $key, bool $deleteIfExpired = true)
     {

--- a/src/voku/cache/AdapterXcache.php
+++ b/src/voku/cache/AdapterXcache.php
@@ -35,7 +35,7 @@ class AdapterXcache implements iAdapter
     /**
      * {@inheritdoc}
      */
-    public function get(string $key)
+    public function get(string $key, bool $deleteIfExpired = true)
     {
         return \xcache_get($key);
     }

--- a/src/voku/cache/AdapterXcache.php
+++ b/src/voku/cache/AdapterXcache.php
@@ -34,6 +34,9 @@ class AdapterXcache implements iAdapter
 
     /**
      * {@inheritdoc}
+     *
+     * Note: Xcache automatically handles expiration at the storage level.
+     * The $deleteIfExpired parameter has no effect for this adapter.
      */
     public function get(string $key, bool $deleteIfExpired = true)
     {

--- a/src/voku/cache/iAdapter.php
+++ b/src/voku/cache/iAdapter.php
@@ -13,11 +13,12 @@ interface iAdapter
      * Get cached-item by key.
      *
      * @param string $key
+     * @param bool   $deleteIfExpired  <p>If true, delete the cache entry if it's expired (default: true)</p>
      *
      * @return mixed|null
      *                    <p>will return NULL if the key not exists</p>
      */
-    public function get(string $key);
+    public function get(string $key, bool $deleteIfExpired = true);
 
     /**
      * Set cache-item by key => value.

--- a/tests/DeleteIfExpiredFileTest.php
+++ b/tests/DeleteIfExpiredFileTest.php
@@ -1,0 +1,147 @@
+<?php
+
+use voku\cache\AdapterFile;
+use voku\cache\Cache;
+use voku\cache\iAdapter;
+use voku\cache\iSerializer;
+use voku\cache\SerializerDefault;
+
+/**
+ * DeleteIfExpiredFileTest
+ *
+ * Test the new deleteIfExpired parameter in get() method with file adapter
+ *
+ * @internal
+ */
+final class DeleteIfExpiredFileTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var iSerializer
+     */
+    public $serializer;
+
+    /**
+     * @var iAdapter
+     */
+    public $adapter;
+
+    /**
+     * @var Cache
+     */
+    public $cache;
+
+    protected $backupGlobalsBlacklist = [
+        '_SESSION',
+    ];
+
+    public function testGetWithDeleteIfExpiredTrue()
+    {
+        // Set an item with 1 second TTL
+        $return = $this->cache->setItem('test_key_file', 'test_value', 1);
+        static::assertTrue($return);
+
+        // Get item immediately - should exist
+        $return = $this->cache->getItem('test_key_file');
+        static::assertSame('test_value', $return);
+
+        // Get the actual store key that Cache uses (it's hashed)
+        $reflection = new \ReflectionClass($this->cache);
+        $method = $reflection->getMethod('calculateStoreKey');
+        $method->setAccessible(true);
+        $storeKey = $method->invoke($this->cache, 'test_key_file');
+
+        // Wait for expiration
+        \sleep(2);
+
+        // Get with deleteIfExpired=true (default) - should return null and delete the item
+        $return = $this->adapter->get($storeKey, true);
+        static::assertNull($return);
+
+        // Verify the item was deleted (file should not exist)
+        $return = $this->adapter->exists($storeKey);
+        static::assertFalse($return);
+    }
+
+    public function testGetWithDeleteIfExpiredFalse()
+    {
+        // Set an item with 1 second TTL
+        $return = $this->cache->setItem('test_key_file2', 'test_value2', 1);
+        static::assertTrue($return);
+
+        // Get item immediately - should exist
+        $return = $this->cache->getItem('test_key_file2');
+        static::assertSame('test_value2', $return);
+
+        // Get the actual store key that Cache uses (it's hashed)
+        $reflection = new \ReflectionClass($this->cache);
+        $method = $reflection->getMethod('calculateStoreKey');
+        $method->setAccessible(true);
+        $storeKey = $method->invoke($this->cache, 'test_key_file2');
+
+        // Wait for expiration
+        \sleep(2);
+
+        // Get with deleteIfExpired=false - should return null but NOT delete the item
+        // Use the store key, not the original key
+        $return = $this->adapter->get($storeKey, false);
+        static::assertNull($return);
+
+        // With file adapter, we can check if the file still exists
+        assert($this->adapter instanceof AdapterFile);
+        // Use reflection to get the file name
+        $reflection = new \ReflectionClass($this->adapter);
+        $method = $reflection->getMethod('getFileName');
+        $method->setAccessible(true);
+        $fileName = $method->invoke($this->adapter, $storeKey);
+        
+        static::assertTrue(\file_exists($fileName), 'File should still exist when deleteIfExpired=false');
+        
+        // Now call get with deleteIfExpired=true (default) and verify it gets deleted
+        $return = $this->adapter->get($storeKey, true);
+        static::assertNull($return);
+        static::assertFalse(\file_exists($fileName), 'File should be deleted when deleteIfExpired=true');
+    }
+
+    public function testGetWithDefaultBehavior()
+    {
+        // Set an item with 1 second TTL
+        $return = $this->cache->setItem('test_key_file3', 'test_value3', 1);
+        static::assertTrue($return);
+
+        // Get the actual store key that Cache uses (it's hashed)
+        $reflection = new \ReflectionClass($this->cache);
+        $method = $reflection->getMethod('calculateStoreKey');
+        $method->setAccessible(true);
+        $storeKey = $method->invoke($this->cache, 'test_key_file3');
+
+        // Wait for expiration
+        \sleep(2);
+
+        // Get without specifying deleteIfExpired - should use default (true) and delete
+        $return = $this->adapter->get($storeKey);
+        static::assertNull($return);
+
+        // Verify the item was deleted (default behavior)
+        $return = $this->adapter->exists($storeKey);
+        static::assertFalse($return);
+    }
+
+    /**
+     * @before
+     */
+    protected function setUpThanksForNothing()
+    {
+        $cacheDir = \sys_get_temp_dir() . '/simple_php_cache_test_delete_if_expired';
+        
+        $this->adapter = new AdapterFile($cacheDir);
+        $this->serializer = new SerializerDefault();
+
+        $this->cache = new Cache($this->adapter, $this->serializer, false, true);
+
+        // reset default prefix
+        $this->cache->setPrefix('');
+        
+        // Clear all cache to ensure clean state
+        $this->adapter->removeAll();
+    }
+}

--- a/tests/DeleteIfExpiredTest.php
+++ b/tests/DeleteIfExpiredTest.php
@@ -109,7 +109,7 @@ final class DeleteIfExpiredTest extends \PHPUnit\Framework\TestCase
 
         // reset default prefix
         $this->cache->setPrefix('');
-        
+
         // Clear all cache to ensure clean state
         $this->adapter->removeAll();
     }

--- a/tests/DeleteIfExpiredTest.php
+++ b/tests/DeleteIfExpiredTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use voku\cache\AdapterArray;
+use voku\cache\Cache;
+use voku\cache\iAdapter;
+use voku\cache\iSerializer;
+use voku\cache\SerializerDefault;
+
+/**
+ * DeleteIfExpiredTest
+ *
+ * Test the new deleteIfExpired parameter in get() method
+ *
+ * @internal
+ */
+final class DeleteIfExpiredTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var iSerializer
+     */
+    public $serializer;
+
+    /**
+     * @var iAdapter
+     */
+    public $adapter;
+
+    /**
+     * @var Cache
+     */
+    public $cache;
+
+    protected $backupGlobalsBlacklist = [
+        '_SESSION',
+    ];
+
+    public function testGetWithDeleteIfExpiredTrue()
+    {
+        // Set an item with 1 second TTL
+        $return = $this->cache->setItem('test_key', 'test_value', 1);
+        static::assertTrue($return);
+
+        // Get item immediately - should exist
+        $return = $this->cache->getItem('test_key');
+        static::assertSame('test_value', $return);
+
+        // Wait for expiration
+        \sleep(2);
+
+        // Get with deleteIfExpired=true (default) - should return null and delete the item
+        $return = $this->adapter->get('test_key', true);
+        static::assertNull($return);
+
+        // Verify the item was deleted
+        $return = $this->adapter->exists('test_key');
+        static::assertFalse($return);
+    }
+
+    public function testGetWithDeleteIfExpiredFalse()
+    {
+        // Set an item with 1 second TTL
+        $return = $this->cache->setItem('test_key2', 'test_value2', 1);
+        static::assertTrue($return);
+
+        // Get item immediately - should exist
+        $return = $this->cache->getItem('test_key2');
+        static::assertSame('test_value2', $return);
+
+        // Wait for expiration
+        \sleep(2);
+
+        // Get with deleteIfExpired=false - should return null but NOT delete the item
+        $return = $this->adapter->get('test_key2', false);
+        static::assertNull($return);
+
+        // With AdapterArray, we can check that the value is still in storage
+        assert($this->adapter instanceof AdapterArray);
+        $keys = $this->adapter->getStaticKeys();
+        static::assertTrue(\in_array('test_key2', $keys), 'Key should still exist in storage when deleteIfExpired=false');
+    }
+
+    public function testGetWithDefaultBehavior()
+    {
+        // Set an item with 1 second TTL
+        $return = $this->cache->setItem('test_key3', 'test_value3', 1);
+        static::assertTrue($return);
+
+        // Wait for expiration
+        \sleep(2);
+
+        // Get without specifying deleteIfExpired - should use default (true) and delete
+        $return = $this->adapter->get('test_key3');
+        static::assertNull($return);
+
+        // Verify the item was deleted (default behavior)
+        $return = $this->adapter->exists('test_key3');
+        static::assertFalse($return);
+    }
+
+    /**
+     * @before
+     */
+    protected function setUpThanksForNothing()
+    {
+        $this->adapter = new AdapterArray();
+        $this->serializer = new SerializerDefault();
+
+        $this->cache = new Cache($this->adapter, $this->serializer, false, true);
+
+        // reset default prefix
+        $this->cache->setPrefix('');
+        
+        // Clear all cache to ensure clean state
+        $this->adapter->removeAll();
+    }
+}


### PR DESCRIPTION
This can happen for example when multiple requests access the same expired cache entry.
One of them unlinks the file first and the other tries to remove nonexistent file and logs error.
And because of statcache, it doesn't even have to happen right after the `is_file` check.

I suppressed only the lines I found in the logs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/simple-cache/35)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `deleteIfExpired` parameter to cache retrieval, allowing control over automatic deletion of expired entries while maintaining backward compatibility with default deletion behavior.

* **Bug Fixes**
  * Improved error handling in file-based cache operations to suppress warnings on missing or inaccessible files.

* **Tests**
  * Added comprehensive test coverage for cache expiration and deletion behavior across different adapter types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->